### PR TITLE
Overhaul of MotorControl, servo is continous

### DIFF
--- a/interface.cpp
+++ b/interface.cpp
@@ -7,7 +7,7 @@ class MotorControl {
     private:
         Servo motor;
         enum MotorState {Rotating, Stopped};
-        MotorState state = Stopped;
+        MotorState state;
         int stoppedTimeStamp;
         int rotatingTimeStamp;
         int STOPPED_TIME_MS = 1000;
@@ -31,6 +31,28 @@ class MotorControl {
          */
         int getSpeed() {
             return motor.read();
+        }
+
+        /**
+         * @brief Used to check if the motor was last stopped timeMs ago.
+         * 
+         * @param timeMs - The amount of time in MS to check the motor has stopped for
+         * @return true - When it has been atleast timeMs since stoppedTimeStamp was set 
+         * @return false - Otherwise
+         */
+        bool hasStoppedFor(int timeMs) {
+            return (stoppedTimeStamp + timeMs) < millis();
+        }
+
+        /**
+         * @brief Used to check if the motor was last rotating timeMs ago
+         * 
+         * @param timeMs - The amount of time in MS to check the motor has been rotating for
+         * @return true - When the motor has been atleast timeMS since rotatingTimeStamp was set.
+         * @return false - Otherwise
+         */
+        bool hasRotatedFor(int timeMs) {
+            return (rotatingTimeStamp + timeMs) < millis();
         }
 
         /**
@@ -62,7 +84,7 @@ class MotorControl {
          */
         MotorControl(int motorPin) {
             motor.attach(motorPin);
-            stoppedTimeStamp = millis();
+            stop();
         }
 
         /**
@@ -70,12 +92,10 @@ class MotorControl {
          * 
          */
         void run() {
-            int currentTimeStamp = millis();
-            // Has the motor been running for long enough?
-            if(state == Stopped && stoppedTimeStamp + STOPPED_TIME_MS < currentTimeStamp)
+            if(state == Stopped && hasStoppedFor(STOPPED_TIME_MS))
             {
                 rotate();
-            } else if (state == Rotating && rotatingTimeStamp + ROTATE_TIME_MS < currentTimeStamp)
+            } else if (state == Rotating && hasRotatedFor(ROTATE_TIME_MS))
             {
                 stop();
             }

--- a/interface.cpp
+++ b/interface.cpp
@@ -6,6 +6,52 @@ class MotorControl {
     // Assignee: COLM
     private:
         Servo motor;
+        enum MotorState {Rotating, Stopped};
+        MotorState state = Stopped;
+        int stoppedTimeStamp;
+        int rotatingTimeStamp;
+        int STOPPED_TIME_MS = 1000;
+        int ROTATE_TIME_MS = 5000;
+        int STOPPED_SPEED = 0;
+        int ROTATE_SPEED = 180;
+
+        /**
+         * @brief Set the Speed object
+         * 
+         * @param speed The speed of the continuous motor
+         */
+        void setSpeed(int speed) {
+            motor.write(speed);
+        }
+
+        /**
+         * @brief Get the Speed object
+         * 
+         * @return int the speed of the continuous motor
+         */
+        int getSpeed() {
+            return motor.read();
+        }
+
+        /**
+         * @brief Stops the motor from turning.
+         * 
+         */
+        void stop() {
+            stoppedTimeStamp = millis();
+            state = Stopped;
+            setSpeed(STOPPED_SPEED);
+        }
+
+        /**
+         * @brief Starts the motor rotating
+         * 
+         */
+        void rotate() {
+            rotatingTimeStamp = millis();
+            state = Rotating;
+            setSpeed(ROTATE_SPEED);
+        }
 
     public:
 
@@ -16,7 +62,26 @@ class MotorControl {
          */
         MotorControl(int motorPin) {
             motor.attach(motorPin);
+            stoppedTimeStamp = millis();
         }
+
+        /**
+         * @brief Runs the motor stopping mechanism.
+         * 
+         */
+        void run() {
+            int currentTimeStamp = millis();
+            // Has the motor been running for long enough?
+            if(state == Stopped && stoppedTimeStamp + STOPPED_TIME_MS < currentTimeStamp)
+            {
+                rotate();
+            } else if (state == Rotating && rotatingTimeStamp + ROTATE_TIME_MS < currentTimeStamp)
+            {
+                stop();
+            }
+        }
+
+        // LEGACY INTERFACE DESIGN, HERE INCASE WE DON'T GET CONTINOUS MOTOR.
         /**
          * @brief Rotates the motor the specified number of degrees.
          * 


### PR DESCRIPTION
- Legacy interface remains usbale in the event we cannot get the continuous motor.
- The new public interface only has a run function. This function will stop and start the screw in intervals defined as constants in the class.
- Private functions added, setSpeed(int speed), getSpeed(), stop(), and rotate()
- Constructor now also sets the initial stoppedTimeStamp.